### PR TITLE
Use overlay Docker storage for seed CI

### DIFF
--- a/etc/kayobe/docker.yml
+++ b/etc/kayobe/docker.yml
@@ -4,8 +4,7 @@
 
 # Name of the docker storage driver. Supported values include 'devicemapper'
 # and 'overlay'.
-# NOTE: This is configured in group_vars for the seed and overcloud groups.
-#docker_storage_driver:
+docker_storage_driver: overlay
 
 # Name of the docker storage LVM volume group.
 #docker_storage_volume_group:

--- a/etc/kayobe/inventory/group_vars/overcloud/docker
+++ b/etc/kayobe/inventory/group_vars/overcloud/docker
@@ -1,3 +1,0 @@
----
-# Use the overlay docker storage driver as it doesn't require LVM.
-docker_storage_driver: overlay

--- a/etc/kayobe/inventory/group_vars/seed/docker
+++ b/etc/kayobe/inventory/group_vars/seed/docker
@@ -1,7 +1,0 @@
----
-# Don't use the overlay driver as it doesn't work with the ansible template
-# module until ansible 2.4.0.
-docker_storage_driver: devicemapper
-
-# Size of the docker storage data LVM volume (see lvol module size argument).
-docker_storage_volume_thinpool_size: 45%VG

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -23,7 +23,9 @@
 
 # List of seed volume groups. See mrlesmithjr.manage-lvm role for
 # format.
-#seed_lvm_groups:
+# NOTE: We set this to an empty list here because the default Docker storage
+# driver (overlay) does not require any LVM groups.
+seed_lvm_groups: []
 
 # Default list of seed volume groups. See mrlesmithjr.manage-lvm role for
 # format.


### PR DESCRIPTION
Bifrost is now able to support the overlay Docker storage driver.
Switch to using it instead of devicemapper with a logical volume mounted
on a loopback device.